### PR TITLE
select radio when corresponding select is changed, addresses #696

### DIFF
--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -2,7 +2,7 @@
 <div class="form-group" id="kubespawner-profiles-list">
   {%- for profile in profile_list %}
     {#- Wrap everything in a label tag so clicking anywhere selects the option #}
-    <label for="profile-item-{{ profile.slug }}" class="profile">
+    <label for="profile-item-{{ profile.slug }}" class="profile js-profile-label">
       <div class="radio">
         <input type="radio"
                name="profile"
@@ -18,7 +18,7 @@
             {%- for k, option in profile.profile_options.items() %}
               <div class="option">
                 <label for="profile-option-{{ profile.slug }}-{{ k }}">{{ option.display_name }}</label>
-                <select name="profile-option-{{ profile.slug }}-{{ k }}" class="form-control">
+                <select name="profile-option-{{ profile.slug }}-{{ k }}" class="js-profile-option-select form-control">
                   {%- for k, choice in option['choices'].items() %}
                     <option value="{{ k }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
                   {%- endfor %}
@@ -31,3 +31,10 @@
     </label>
   {%- endfor %}
 </div>
+<script>
+  $('.js-profile-option-select').change(function() {
+    // if the user changes a select box of an option,
+    // make sure we also select that option
+    $(this).parents('.js-profile-label').find('input[type=radio]').prop('checked', true);
+  });
+</script>

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -33,8 +33,10 @@
 </div>
 <script>
   $('.js-profile-option-select').change(function() {
-    // if the user changes a select box of an option,
-    // make sure we also select that option
-    $(this).parents('.js-profile-label').find('input[type=radio]').prop('checked', true);
+    // if the user changes a select box of a profile option,
+    // make sure we also select the radio button for that option
+    $(this).parents('.js-profile-label')
+      .find('input[type=radio]')
+      .prop('checked', true);
   });
 </script>


### PR DESCRIPTION
Addresses https://github.com/jupyterhub/kubespawner/issues/696

Does:
 - Adds `js-` prefixed classes to the Select boxes and the Label containers - this is not strictly necessary, but I find it good practice to separate out classes used by Javascript
 - Adds a `<script>` tag to the end of the template with simple jQuery to react to changes to the select tag and ensure that the parent Input Radio is selected.

Stylistic choices:

 - I've gone ahead and used jQuery since it existed - happy to remove the dependency, but it would mean a bit more verbose code.
 - There's probably a few different ways to handle traversing the DOM and selecting the correct radio, probably with different trade-offs. I've gone for the simplest approach here: this does mean that this function would need to be looked at in case the HTML structure of the page drastically changes, but hopefully it's simple enough to tell what's going on here that it would be easy to fix.

Let me know if this works / if there's anything else that would be good to do here.

cc @yuvipanda 